### PR TITLE
demo2

### DIFF
--- a/trade_remedies_public/cases/urls.py
+++ b/trade_remedies_public/cases/urls.py
@@ -39,6 +39,11 @@ urlpatterns = [
         name="invite_people",
     ),
     path(
+        "inviteThirdParty/<uuid:case_id>/people/",
+        case_views.CaseInviteThirdPartyPeopleView.as_view(),
+        name="invite_people",
+    ),
+    path(
         "invite/<uuid:case_id>/<uuid:submission_id>/people/",
         case_views.CaseInvitePeopleView.as_view(),
         name="invite_people_sub",

--- a/trade_remedies_public/templates/account/team.html
+++ b/trade_remedies_public/templates/account/team.html
@@ -190,6 +190,7 @@
       {% endif %}
 
       <a class="button margin-top-1" href="/accounts/team/{{user.organisation.id}}/user/create/">Invite colleague</a>
+      <a class="button margin-top-1" href="/accounts/team/{{user.organisation.id}}/inviteThirdParty/">Invite third party</a>
 
       <div class="margin-top-1">
         <a class="link" href="/dashboard/">Back</a>

--- a/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/download.html
+++ b/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/download.html
@@ -1,0 +1,11 @@
+{% extends '../base_download.html' %}
+{% load confidential %}
+
+{% block breadcrumb_current %}Invite a 3rd party{% endblock %}
+{% block page_subtitle %}3. Download letter of authority template{% endblock %}
+{% block page_title  %}Download letter of authority template{% endblock %}
+
+{% block download_message %}
+    <p>Download and complete the letter of authority template below.</p>
+    <p>You can upload a single letter of authority for all invitees or individual ones.</p>
+{% endblock %}

--- a/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/inviteThirdParty.html
+++ b/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/inviteThirdParty.html
@@ -1,0 +1,71 @@
+{% extends '../base_tasklist.html' %}
+{% load task_link_toggle %}
+{% load error_message %}
+{% load task_status %}
+
+{% block breadcrumb_current %}Invite a 3rd party{% endblock %}
+
+{% block header %}
+    <h1 class="heading-large">
+        Invite a 3rd party
+    </h1>
+
+    <p class="lede">Invite 3rd parties to participate in a case on behalf of {{organisation.name}}</p>
+{% endblock %}
+
+{% block submission_received_title %}3rd party invited{% endblock %}
+
+{% block submission_received_message %}<p>This application has been submitted.</p>
+    <p>If you want to report an omission, error or material change contact the <a target="_blank" href="/contact" class="nobreak">{% include "partials/TRID_full_name.html" %}</a>.</p>
+{% endblock %}
+
+{% block tasklist_content %}
+    <li>
+        <div class="edit-item" data-section="143">
+            <h2 class="task-list-section">
+                <span class="task-list-section-number">1. </span>
+                <span class="task-list-section-title">Which case are you interested in?</span>
+            </h2>
+        </div>
+        <ul class="task-list-items">
+            <li class="task-list-item edit-item" data-section="27">
+                {% if case %}
+                    {% task_status 'COMPLETE' %}
+                    <div>{{case.reference}}: {{case.name}}</div>
+                {% else %}
+                    <a href="/case/select/?redirect=invite_top">Select case</a>
+                {% endif %}
+            </li>
+        </ul>
+    </li>
+    <li>
+        <div class="edit-item" data-section="143">
+            <h2 class="task-list-section">
+                <span class="task-list-section-number">2. </span>
+                <span class="task-list-section-title">Tell us who you are inviting</span>
+            </h2>
+        </div>
+        <ul class="task-list-items">
+            <li class="task-list-item edit-item" data-section="27">
+                {% if case %}
+                    <a href="/case/inviteThirdParty/{{case.id}}/people/">Add Invitees</a>
+                    {% if invites|length > 0 %}
+                        {% count_display invites|length 'Invites' '' %}
+                    {% endif %}
+                {% else %}
+                    Add Invitees
+                {% endif %}
+            </li>
+        </ul>
+    </li>
+
+    {% include "partials/task_list/download_documents.html" with item_heading="Download Letter of Authority" section_counter=3 %}
+
+    {% include "partials/task_list/upload_confidential_documents.html" with section_heading='Upload forms' item_heading="Upload Letter of Authority" section_counter=4 enable=True %}
+
+    {% include "partials/task_list/submit.html" with section_counter=5 section_heading='Submit your invitation request'%}
+
+{% endblock %}
+
+{% block cancel_button_text %}Cancel invititation{% endblock  %}
+{% block cancel_button_redirect %}/dashboard/{% endblock  %}

--- a/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/invites.html
+++ b/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/invites.html
@@ -1,0 +1,66 @@
+{% extends "../base_form.html" %}
+
+{% block breadcrumb_current %}Invite 3rd party{% endblock %}
+{% block page_subtitle %}2. Add people to invite{% endblock %}
+{% block page_title  %}Invitees{% endblock %}
+
+{% block subtype_content %}
+<div class="grid-row">
+    <table class="cases" data-attach="TableSort">
+      <thead>
+        <tr>
+          <th class="text">Name</th>
+          <th class="case-name">Email</th>
+          <th class="type">Organisation</th>
+          <th class="applicant">Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for invite in invites %}
+          <tr>
+              <td>{{invite.contact.name}}</td>
+              <td>{{invite.email}}</td>
+              <td>
+                {{invite.contact.organisation.name}}
+              </td>
+              <td></td>
+              <td><a href="/case/invite/{{case.id}}/{{submission.id}}/people/remove/{{invite.id}}/">Remove</a></td>
+          </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+
+
+    <div class="column-two-thirds">
+        <div id="block-1035" class="form-group edit-item type-select ">
+            <label class="form-label" for="field-1035">Invite</label>
+            {% if submission.locked %}
+                {{invite.name}}
+            {% else %}
+            <label class="form-label" for="name">Name</label>
+            <input type="text" class="form-control" id="name" name="name" value="{{invite.name}}">
+            <label class="form-label" for="email">Email</label>
+            <input type="text" class="form-control" id="email" name="email" autocomplete="off" value="{{invite.email}}">
+
+            <div id="typeAheadWrapper" class="form-group type-text type-typeahead" data-validate=".+->You must provide a company" >
+                <label class="form-label" for="company">UK Company name</label>
+                <input class="form-control form-control-3-4" id="company" type="text" data-mode="company" name="organisation_name" value="{{organisation.name}}" autocomplete="new-password">
+            </div>
+            <div class="form-group type-text" >
+                <label class="form-label" for="company_number">Company number</label>
+                <input class="form-control" id="company_number" type="text" name="companies_house_id" value="{{organisation.companies_house_id}}">
+            </div>
+            <div class="form-group type-text" >
+                <label class="form-label" for="company_number">Address</label>
+                <input class="form-control" id="postal_code" type="hidden" name="organisation_post_code" value="{{organisation.post_code}}">
+                <textarea class="form-control-3-4" rows="5" id="full_address" type="text" name="organisation_address">{{ organisation.address }}</textarea>
+            </div>
+        {% endif %}
+        </div>
+
+    </div>
+
+</div>
+
+{% endblock %}

--- a/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/submit.html
+++ b/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/submit.html
@@ -1,0 +1,18 @@
+{% extends "../base_submit.html" %}
+{% block breadcrumb_current %}Invite a 3rd Party{% endblock %}
+{% block page_subtitle %}5. Submit your request to invite a 3rd party{% endblock %}
+{% block page_title  %}Final check and submission{% endblock %}
+
+{% block submission_main_text %}
+    <p>Once you submit this form you will not be able to make changes to your submitted information. If you become aware of any errors or omissions please notify the {% include "partials/TRID_full_name.html" %} as quickly as possible.</p>
+    <p>The information contained within your request to invite 3rd parties to the case will be considered to be confidential and will not be shared with third parties.</p>
+{% endblock %}
+
+{% block conf_box %}
+	<input type="hidden" name="non_conf" value="included-non-conf">
+{% endblock %}
+
+{% block submission_checkbox_label %}
+    I have completed my request to invite 3rd parties to the case and I am happy for the {% include "partials/TRID_full_name.html" %} to consider it
+{% endblock %}
+

--- a/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/upload.html
+++ b/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/upload.html
@@ -1,0 +1,16 @@
+{% extends "../base_conf_nonconf.html" %}
+{% load set %}
+
+{% block breadcrumb_current %}Invite a 3rd party{% endblock %}
+{% block page_subtitle %}4. Upload letter of authority{% endblock %}
+{% block page_title  %}Upload letter of authority{% endblock %}
+
+{% block label %}Upload your completed Letter of Authority form.{% endblock %}
+
+{% block subtype_content %}
+	{% set 'one_column' True %}
+	{{ block.super }}
+{% endblock %}
+
+
+

--- a/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/view.html
+++ b/trade_remedies_public/templates/cases/submissions/thirdPartyInvite/view.html
@@ -1,0 +1,36 @@
+{% extends "../base_view.html" %}
+
+{% block breadcrumb_current %}Invite a 3rd party{% endblock %}
+{% block page_subtitle %}Your 3rd party invitation{% endblock %}
+{% block page_title  %}Invite submitted{% endblock %}
+
+    {% block action_block %}
+        {% if case %}
+            <div>
+                You have requested to invite 3rd parties to :<br>
+                <strong >{{case.reference}}: {{case.name}}</strong>
+            </div>
+        {% endif %}
+    {% endblock %}
+
+{% block status_block %}
+    {% if submission.status.sufficient %}
+    This invitiation was accepted.
+    {% endif %}
+
+    The following were sent invitations to join your view of this case:
+    <table>
+        <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Organisation</th>
+        </tr>
+        {% for invite in invites %}
+        <tr>
+            <td>{{invite.contact.name}}</td>
+            <td>{{invite.contact.email}}</td>
+            <td>{{invite.organisation.name}}</td>
+        </tr>
+        {% endfor %}
+    </table>
+{% endblock %}

--- a/trade_remedies_public/templates/dashboard.html
+++ b/trade_remedies_public/templates/dashboard.html
@@ -89,7 +89,7 @@
             <h1 class="heading-medium">Other things you can do</h1>
             <ul>
               {% if pre_register_interest %}<li><a href="/case/interest/">Register interest in a case</a></li>{% endif %}
-              {% comment %}{% if pre_invitations %}<li><a href="/case/invite/">Invite a 3rd party</a></li>{% endif %}{% endcomment %}
+              {% if pre_invitations %}<li><a href="/case/invite/">Invite a 3rd party</a></li>{% endif %}
               {% if pre_applications %}<li><a href="/case/">Apply for an investigation</a></li>{% endif %}
               {% if pre_manage_team and is_org_owner %}<li><a href="/accounts/team/">Manage your team</a></li>{% endif %}
               {% if pre_manage_team and is_org_owner %}<li><a href="/cases/">See all cases</a></li>{% endif %}

--- a/trade_remedies_public/trade_remedies_public/urls.py
+++ b/trade_remedies_public/trade_remedies_public/urls.py
@@ -177,6 +177,12 @@ urlpatterns = [
         core_views.TeamUserView.as_view(),
         name="user_view",
     ),
+    path(
+        "accounts/team/<uuid:organisation_id>/inviteThirdParty/",
+        core_views.InviteThirdPartyView.as_view(),
+        name="user_view",
+    ),
+
     # User assignment to cases
     path(
         "accounts/team/assign/<uuid:user_id>/",


### PR DESCRIPTION
Pull request for review for public site component of second attempt to implement Third Party Invitations

This second attempt was made further to a conversation with Tipu about using existing functionality.  Existing mechanism was not deemed appropriate as it only invites the user to the system and does not bring the invited user directly to the case.

This was the code used for the demo of 16th November to David and Luiselle and on 13th November to Tipu.

In first attempt, had tried to fit the new workflow within the existing mechanisms, but this led to slow progress.  Therefore, the theme of the second attempt was to copy code where  needed to make it independent of the exisiting codebase and change it to meet precise requirements.

Note that the file download does not work - possibly an issue with one of the urls / redirections around the people area of the workflow.

Comments on individual files additions and changes as follows:

 trade_remedies_public/templates/account/team.html
- this sets up the extra button from which to start the workflow
- the button was set up to enable rapid progress in this second attempt
- in the first attempt - see other PR for public - the control is implemented as specified in Tipu's pdf document

 trade_remedies_public/cases/submissions.py
- changes to get_context: attempts to get the download documents to display - recommend discard
- added on_submit: this invites the user to the case - believe this is no longer needed - recommend test without this and discard

 trade_remedies_public/cases/urls.py
- added new path for Third Party People 
- this was to get the workflow working
- probably need to update case_views.CaseInviteThirdPartyPeopleView in order to get download to work
- i.e. add an appropriate redirect url

 trade_remedies_public/cases/views.py
- added class CaseInviteThirdPartyPeopleView to support specification of 3rd parties to invite

 trade_remedies_public/core/views.py
- added class InviteThirdPartyView to support 3rd party invitation workflow

 trade_remedies_public/templates/cases/submissions/thirdPartyInvite/inviteThirdParty.html 
- main html page for the third party invitation workflow

 trade_remedies_public/templates/cases/submissions/thirdPartyInvite/invites.html 
- form for details of invitee

 trade_remedies_public/templates/cases/submissions/thirdPartyInvite/submit.html 
- submission page for the third party invitation workflow

 trade_remedies_public/templates/cases/submissions/thirdPartyInvite/upload.html
- html fragment to support file upload

 trade_remedies_public/templates/cases/submissions/thirdPartyInvite/view.html
- html to support viewing details of a 3rd party invitation 

 trade_remedies_public/templates/dashboard.html
- this link is not needed in the current implementation
- it provides access to the worflow already implemented by your supplier that the powers that be have decided not to use
- i.e. it is suggested that you restore / retain the code as a comment

 trade_remedies_public/trade_remedies_public/urls.py
- sets up link from which to start the third party invites workflow

