### PR TITLE
fix: Third party invite fails when no case.

### DIFF
--- a/trade_remedies_public/cases/views.py
+++ b/trade_remedies_public/cases/views.py
@@ -1341,7 +1341,7 @@ class CaseInviteView(LoginRequiredMixin, GroupRequiredMixin, BasePublicView):
                 "organisation": request.user.organisation,
                 "organisation_name": request.user.organisation.get("name", "unknown"),
                 "documents": documents,
-                "application": request.session["application"],
+                "application": request.session.get("application", "unknown"),
                 "invitee_name": invitee_name,
             },
         )


### PR DESCRIPTION
When there are no cases for a public portal user and they
attempt to invite a 3rd party, the view's `get` method fails
because the request has no application (which is not required
at this point in the journey).

Used a dict.get and default value instead of [] notation.