### PR TITLE
Feature/trlst 174 invite mechanics

### DIFF
--- a/trade_remedies_public/cases/submissions.py
+++ b/trade_remedies_public/cases/submissions.py
@@ -4,7 +4,6 @@ from trade_remedies_client.client import Client
 from django_countries import countries
 from core.utils import get
 from cases.constants import (
-    CASE_DOCUMENT_TYPE_LETTER_OF_AUTHORISATION,
     SUBMISSION_TYPE_ASSIGN_TO_CASE,
     CASE_ROLE_PREPARING,
 )
@@ -74,19 +73,9 @@ class InviteThirdPartySubmission(BaseSubmissionHelper):
             return context
 
         invites = []
-        documents = []
         if self.submission:
             invites = self.client.get_third_party_invites(self.case_id, self.submission["id"])
-            case_documents = self.client.get_case_documents(
-                self.case_id, CASE_DOCUMENT_TYPE_LETTER_OF_AUTHORISATION
-            )
-            documents = [doc for doc in case_documents]
         context["invites"] = invites
-        context["case_documents"] = documents
-        if "documents" in context:
-            context["documents"]["caseworker"] += documents
-        else:
-            context["documents"] = {"caseworker": documents}
         return context
 
 

--- a/trade_remedies_public/cases/views.py
+++ b/trade_remedies_public/cases/views.py
@@ -1373,7 +1373,7 @@ class CaseInvitePeopleView(LoginRequiredMixin, GroupRequiredMixin, BasePublicVie
                 "organisation": request.user.organisation,
                 "organisation_name": request.user.organisation.get("name", "unknown"),
                 "documents": submission_documents,
-                "application": request.session["application"],
+                "application": request.session.get("application", "unknown"),
                 "invitee": invitee,
                 "invite": invitee["contact"] if invitee else None,
             },

--- a/trade_remedies_public/templates/cases/submissions/invite/download_deficiency.html
+++ b/trade_remedies_public/templates/cases/submissions/invite/download_deficiency.html
@@ -1,0 +1,10 @@
+{% extends 'cases/submissions/base_download.html' %}
+
+{% block breadcrumb_current %}Invite 3rd Party{% endblock %}
+{% block page_subtitle %}3. Download forms and notices{% endblock %}
+{% block page_title  %}Download deficiency notice{% endblock %}
+
+{% block download_message %}
+    <p>Download the deficiency notices below for guidance on how to continue
+       with your 3rd Party invite.</p>
+{% endblock %}


### PR DESCRIPTION
# Implement [TRLST 174](https://uktrade.atlassian.net/browse/TRLST-174) Third Party Invite mechanics

This PR completes the implementation of the Public Portal 3rd Party Invite journey.

- Added a new template based on base_download.html to enable rendering for third party deficiency notice download
  page.
- Includes a fix to maintain context documents, the context already contains the required submission documents
  so removed some unnecessary code.