### PR TITLE
fix: http error page templates

### DIFF
--- a/trade_remedies_public/templates/400.html
+++ b/trade_remedies_public/templates/400.html
@@ -4,26 +4,27 @@
 {% block main_content %}
     <div class="grid-row">
         <div class="column-two-thirds">
-            <h1 class="heading-large"><span class="heading-secondary">HTTP 404</span>
+            <h1 class="heading-large"><span class="heading-secondary">HTTP 400</span>
                 <i class="icon icon-amber-warning"><span
                         class="visually-hidden">Alert</span></i>
-                Not Found
+                Bad Request
             </h1>
             <p>
-                Oops, the page you requested could not be found. Here are some things
-                you can try:
+                Oops, the server was unable to process the request. Here are some
+                things you can try:
             </p>
             <ul class="list list-bullet double-spaced">
-                <li>If you entered a web address, please check that it was correct.</li>
-                <li>Use your browser's back button and check the link that you clicked.</li>
-                <li>If you clicked a link that brought you to this page, please let us know.</li>
-                <li>Return to the <a class="link" href="/">home page</a> and start
-                    again</li>
+                <li>Check your session has not expired (try to re-login).</li>
+                <li>Check the URL of the page you are attempting to access is correct.
+                    For example, are you using a bookmark or copy-pasted url?
+                </li>
+                <li>Were you uploading a file? Check its size, it may be too big.</li>
+                <li>Try clearing your browser cache and cookies.</li>
             </ul>
             <p><em>If problems persist, please email</em>
                 <span>
              <a class="link break-word"
-                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-404 Error">
+                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-400 Error">
                  help@traderemedies.gov.uk
              </a>
            </span>

--- a/trade_remedies_public/templates/400.html
+++ b/trade_remedies_public/templates/400.html
@@ -5,8 +5,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large"><span class="heading-secondary">HTTP 400</span>
-                <i class="icon icon-amber-warning"><span
-                        class="visually-hidden">Alert</span></i>
+                <i class="icon icon-amber-warning">
+                    <span class="visually-hidden">Alert</span>
+                </i>
                 Bad Request
             </h1>
             <p>

--- a/trade_remedies_public/templates/403.html
+++ b/trade_remedies_public/templates/403.html
@@ -4,26 +4,28 @@
 {% block main_content %}
     <div class="grid-row">
         <div class="column-two-thirds">
-            <h1 class="heading-large"><span class="heading-secondary">HTTP 404</span>
+            <h1 class="heading-large"><span class="heading-secondary">HTTP 403</span>
                 <i class="icon icon-amber-warning"><span
                         class="visually-hidden">Alert</span></i>
-                Not Found
+                Forbidden
             </h1>
             <p>
-                Oops, the page you requested could not be found. Here are some things
-                you can try:
+                Oops, you do not have permission to view the page you requested.
+                Here are some things you can try:
             </p>
             <ul class="list list-bullet double-spaced">
-                <li>If you entered a web address, please check that it was correct.</li>
-                <li>Use your browser's back button and check the link that you clicked.</li>
-                <li>If you clicked a link that brought you to this page, please let us know.</li>
+                <li>Make sure you are logged in.</li>
+                <li>Make sure you are requesting a page you have permission to see.</li>
+                <li>Ask your administrator if your permissions are correctly set.</li>
+                <li>Make sure cookies are enabled for this site.</li>
+                <li>Try clearing your browser cache and cookies.</li>
                 <li>Return to the <a class="link" href="/">home page</a> and start
                     again</li>
             </ul>
             <p><em>If problems persist, please email</em>
                 <span>
              <a class="link break-word"
-                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-404 Error">
+                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-403 Error">
                  help@traderemedies.gov.uk
              </a>
            </span>

--- a/trade_remedies_public/templates/403.html
+++ b/trade_remedies_public/templates/403.html
@@ -5,8 +5,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large"><span class="heading-secondary">HTTP 403</span>
-                <i class="icon icon-amber-warning"><span
-                        class="visually-hidden">Alert</span></i>
+                <i class="icon icon-amber-warning">
+                    <span class="visually-hidden">Alert</span>
+                </i>
                 Forbidden
             </h1>
             <p>

--- a/trade_remedies_public/templates/404.html
+++ b/trade_remedies_public/templates/404.html
@@ -5,8 +5,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large"><span class="heading-secondary">HTTP 404</span>
-                <i class="icon icon-amber-warning"><span
-                        class="visually-hidden">Alert</span></i>
+                <i class="icon icon-amber-warning">
+                    <span class="visually-hidden">Alert</span>
+                </i>
                 Not Found
             </h1>
             <p>
@@ -18,15 +19,16 @@
                 <li>Use your browser's back button and check the link that you clicked.</li>
                 <li>If you clicked a link that brought you to this page, please let us know.</li>
                 <li>Return to the <a class="link" href="/">home page</a> and start
-                    again</li>
+                    again
+                </li>
             </ul>
             <p><em>If problems persist, please email</em>
                 <span>
-             <a class="link break-word"
-                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-404 Error">
-                 help@traderemedies.gov.uk
-             </a>
-           </span>
+         <a class="link break-word"
+            href="mailto:help@traderemedies.gov.uk?subject=Public Portal-404 Error">
+             help@traderemedies.gov.uk
+         </a>
+       </span>
             </p>
         </div>
         <div class="column-one-third">

--- a/trade_remedies_public/templates/500.html
+++ b/trade_remedies_public/templates/500.html
@@ -4,18 +4,32 @@
 {% block main_content %}
 <div class="grid-row">
   <div class="column-two-thirds">
-      
-    <h1 class="heading-large"><span class="heading-secondary">Error 500</span>
-      <i class="icon icon32 icon-amber-warning"></i>Server error
-    </h1>
-      <p>Something went wrong on our server. Here are some things you can try:</p>
+      <h1 class="heading-large"><span class="heading-secondary">HTTP 500</span>
+          <i class="icon icon-alert"><span
+                  class="visually-hidden">Alert</span></i>
+          Server Error
+      </h1>
+      <p>
+          Oops, something has gone wrong. This might be an intermittent
+          issue that will be automatically remediated. In the meantime
+          here are some things you can try:
+      </p>
       <ul class="list list-bullet double-spaced">
-        <li>If you entered a web address, please check that it was correct.</li>
-        <li>Use your browser's back button and check the link that you clicked.</li>
-        <li>If you clicked a link that brought you to this page, please let us know using the contact details on the right.</li>
-        <li>Return to the <a class="link" href="/dashboard/">Trade Remedies service start page.</a></li>      </ul>
+          <li>If you entered a web address, please check that it was correct.</li>
+          <li>Use your browser's back button and check the link that you clicked.</li>
+          <li>If you clicked a link that brought you to this page, please let us know.</li>
+          <li>Return to the <a class="link" href="/">home page</a> and start
+              again.</li>
+      </ul>
+      <p><em>If problems persist, please email</em>
+           <span>
+             <a class="link break-word"
+                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-500 Error">
+                 help@traderemedies.gov.uk
+             </a>
+           </span>
+      </p>
   </div>
-
   <div class="column-one-third">
       {% include "partials/widgets/help_box.html" %}
   </div>

--- a/trade_remedies_public/templates/500.html
+++ b/trade_remedies_public/templates/500.html
@@ -2,36 +2,38 @@
 {% load format_date %}
 
 {% block main_content %}
-<div class="grid-row">
-  <div class="column-two-thirds">
-      <h1 class="heading-large"><span class="heading-secondary">HTTP 500</span>
-          <i class="icon icon-alert"><span
-                  class="visually-hidden">Alert</span></i>
-          Server Error
-      </h1>
-      <p>
-          Oops, something has gone wrong. This might be an intermittent
-          issue that will be automatically remediated. In the meantime
-          here are some things you can try:
-      </p>
-      <ul class="list list-bullet double-spaced">
-          <li>If you entered a web address, please check that it was correct.</li>
-          <li>Use your browser's back button and check the link that you clicked.</li>
-          <li>If you clicked a link that brought you to this page, please let us know.</li>
-          <li>Return to the <a class="link" href="/">home page</a> and start
-              again.</li>
-      </ul>
-      <p><em>If problems persist, please email</em>
-           <span>
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            <h1 class="heading-large"><span class="heading-secondary">HTTP 500</span>
+                <i class="icon icon-alert">
+                    <span class="visually-hidden">Alert</span>
+                </i>
+                Server Error
+            </h1>
+            <p>
+                Oops, something has gone wrong. This might be an intermittent
+                issue that will be automatically remediated. In the meantime
+                here are some things you can try:
+            </p>
+            <ul class="list list-bullet double-spaced">
+                <li>If you entered a web address, please check that it was correct.</li>
+                <li>Use your browser's back button and check the link that you clicked.</li>
+                <li>If you clicked a link that brought you to this page, please let us know.</li>
+                <li>Return to the <a class="link" href="/">home page</a> and start
+                    again.
+                </li>
+            </ul>
+            <p><em>If problems persist, please email</em>
+                <span>
              <a class="link break-word"
                 href="mailto:help@traderemedies.gov.uk?subject=Public Portal-500 Error">
                  help@traderemedies.gov.uk
              </a>
            </span>
-      </p>
-  </div>
-  <div class="column-one-third">
-      {% include "partials/widgets/help_box.html" %}
-  </div>
-</div>
+            </p>
+        </div>
+        <div class="column-one-third">
+            {% include "partials/widgets/help_box.html" %}
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
The existing 404 and 500 templates did not work. Also added 400 and 403 for good measure.