### PR TITLE
feat: remove help mailto.

### DIFF
--- a/trade_remedies_public/templates/400.html
+++ b/trade_remedies_public/templates/400.html
@@ -22,14 +22,6 @@
                 <li>Were you uploading a file? Check its size, it may be too big.</li>
                 <li>Try clearing your browser cache and cookies.</li>
             </ul>
-            <p><em>If problems persist, please email</em>
-                <span>
-             <a class="link break-word"
-                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-400 Error">
-                 help@traderemedies.gov.uk
-             </a>
-           </span>
-            </p>
         </div>
         <div class="column-one-third">
             {% include "partials/widgets/help_box.html" %}

--- a/trade_remedies_public/templates/403.html
+++ b/trade_remedies_public/templates/403.html
@@ -23,14 +23,6 @@
                 <li>Return to the <a class="link" href="/">home page</a> and start
                     again</li>
             </ul>
-            <p><em>If problems persist, please email</em>
-                <span>
-             <a class="link break-word"
-                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-403 Error">
-                 help@traderemedies.gov.uk
-             </a>
-           </span>
-            </p>
         </div>
         <div class="column-one-third">
             {% include "partials/widgets/help_box.html" %}

--- a/trade_remedies_public/templates/404.html
+++ b/trade_remedies_public/templates/404.html
@@ -22,14 +22,6 @@
                     again
                 </li>
             </ul>
-            <p><em>If problems persist, please email</em>
-                <span>
-         <a class="link break-word"
-            href="mailto:help@traderemedies.gov.uk?subject=Public Portal-404 Error">
-             help@traderemedies.gov.uk
-         </a>
-       </span>
-            </p>
         </div>
         <div class="column-one-third">
             {% include "partials/widgets/help_box.html" %}

--- a/trade_remedies_public/templates/500.html
+++ b/trade_remedies_public/templates/500.html
@@ -23,14 +23,6 @@
                     again.
                 </li>
             </ul>
-            <p><em>If problems persist, please email</em>
-                <span>
-             <a class="link break-word"
-                href="mailto:help@traderemedies.gov.uk?subject=Public Portal-500 Error">
-                 help@traderemedies.gov.uk
-             </a>
-           </span>
-            </p>
         </div>
         <div class="column-one-third">
             {% include "partials/widgets/help_box.html" %}

--- a/trade_remedies_public/templates/partials/widgets/help_box.html
+++ b/trade_remedies_public/templates/partials/widgets/help_box.html
@@ -5,6 +5,5 @@
 	<p class="bold margin-bottom-1">Do you need help?</p>
 	<div class="font-xsmall double-spaced">
 		<a class="link" href="{% link_lookup 'LINK_HELP_BOX_GUIDANCE' %}" target="_blank">Read the guidance documents &nbsp;<i class="icon16 icon-outlink" title="Opens in a new tab"></i></a>
-		<span>Email: <a class="link break-word" href="mailto:help@traderemedies.gov.uk">help@traderemedies.gov.uk</a></span><br>
 	</div>
 </div>


### PR DESCRIPTION
The `help@traderemedies.gov.uk` email is being retired and as such needs to be removed from the public portal.