### PR TITLE
fix: TRLST-281 save and continue

### DIFF
--- a/trade_remedies_public/templates/cases/submissions/base_form.html
+++ b/trade_remedies_public/templates/cases/submissions/base_form.html
@@ -8,7 +8,7 @@
     {% block extra_save_button %}
     {% endblock %}
   	{% if not submission.status.locking %}
-    <div class="margin-top-2">
+    <div class="margin-top-0">
       {% block save_button %}
         <button type="submit" class="button" name="btn-action" value="savecontinue">{% block save_button_text %}Save and continue{% endblock %}</button>
       {% endblock %}

--- a/trade_remedies_public/templates/cases/submissions/invite/invites.html
+++ b/trade_remedies_public/templates/cases/submissions/invite/invites.html
@@ -1,39 +1,74 @@
 {% extends "cases/submissions/base_form.html" %}
-
+{% load set %}
 {% block breadcrumb_current %}Invite 3rd party{% endblock %}
 {% block page_subtitle %}2. Add an invitee{% endblock %}
 {% block page_title%}Add Invitee{% endblock %}
 
 {% block subtype_content %}
+{% if contact.organisation.companies_house_id %}
+    {% set 'company_id' contact.organisation.companies_house_id %}
+{% else %}
+    {% set 'company_id' "" %}
+{% endif %}
 <div class="grid-row">
     <div class="column-two-thirds">
-        <div id="block-1035" class="form-group edit-item type-select ">
-            <label class="form-label" for="field-1035">Invite 3rd Party to {{organisation_name}}</label>
+        <div id="block-1035" class="form-group edit-item type-select">
+            <label class="form-label" for="field-1035">
+                Invite 3rd Party to {{inviting_organisation.name}}
+            </label>
             {% if submission.locked %}
-                {{invite.name}}
+                {{contact.name}}
             {% else %}
-            <label class="form-label" for="name">Name</label>
-            <input type="text" class="form-control" id="name" name="name" value="{{invite.name}}">
-            <label class="form-label" for="email">Email</label>
-            <input type="text" class="form-control" id="email" name="email" value="{{invite.email}}">
-
-            <div id="typeAheadWrapper" class="form-group type-text type-typeahead" data-validate=".+->You must provide a company" >
-                <label class="form-label" for="company">Company name</label>
-                <input class="form-control form-control-3-4" id="company" type="text" data-mode="company" name="organisation_name" autocomplete="new-password">
-            </div>
-            <div class="form-group type-text" >
-                <label class="form-label" for="company_number">Company number</label>
-                <input class="form-control" id="company_number" type="text" name="companies_house_id" value="{{organisation.companies_house_id}}">
-            </div>
-            <div class="form-group type-text" >
-                <label class="form-label" for="company_number">Address</label>
-                <input class="form-control" id="postal_code" type="hidden" name="organisation_post_code" value="{{organisation.post_code}}">
-                <textarea class="form-control-3-4" rows="5" id="full_address" type="text" name="organisation_address">{{ organisation.address }}</textarea>
-            </div>
-        {% endif %}
+                <div class="form-group type-text">
+                <label class="form-label" for="name">Name</label>
+                <input class="form-control form-control-3-4"
+                       id="name"
+                       name="name"
+                       type="text"
+                       value="{{contact.name}}">
+                </div>
+                <div class="form-group type-text">
+                <label class="form-label" for="email">Email</label>
+                <input class="form-control form-control-3-4"
+                       id="email"
+                       name="email"
+                       type="text"
+                       value="{{contact.email}}">
+                </div>
+                <div class="form-group type-text type-typeahead"
+                     data-validate="You must provide a company"
+                     id="typeAheadWrapper">
+                    <label class="form-label" for="company">Company name</label>
+                    <input autocomplete="new-password"
+                           class="form-control form-control-3-4"
+                           data-mode="company"
+                           id="company"
+                           name="organisation_name"
+                           type="text"
+                           value="{{contact.organisation.name}}">
+                </div>
+                <div class="form-group type-text">
+                    <label class="form-label" for="company_number">Company number</label>
+                    <input class="form-control"
+                           id="company_number"
+                           name="companies_house_id"
+                           type="text"
+                           value="{{company_id}}">
+                </div>
+                <div class="form-group type-text" >
+                    <label class="form-label" for="company_number">Address</label>
+                    <input class="form-control"
+                           id="postal_code" type="hidden"
+                           name="organisation_post_code"
+                           value="{{contact.organisation.address}}">
+                    <textarea class="form-control-3-4"
+                              id="full_address"
+                              name="organisation_address"
+                              rows="5"
+                              type="text">{{contact.organisation.address}}</textarea>
+                </div>
+            {% endif %}
         </div>
-
     </div>
 </div>
-
 {% endblock %}


### PR DESCRIPTION
This change fixes an issue where a third party invitee's organisation
details were not displayed if the user edited the contact in the submission. 
This was mainly solved in the API, this change extracts the right attr name
for organisation_address as well as tidy up the rendering.