### PR TITLE
feat: TRLST-306 add pip-tools to dev deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 APPLICATION_NAME="Trade Remedies Public"
 
 # Colour coding for output
@@ -5,18 +6,21 @@ COLOUR_NONE=\033[0m
 COLOUR_GREEN=\033[32;01m
 COLOUR_YELLOW=\033[33;01m
 
+ifeq ($(APPLICATION_VERSION),)
+APPLICATION_VERSION := "no version"
+endif
 
 .PHONY: help test
 help:
-		@echo -e "$(COLOUR_GREEN)|--- $(APPLICATION_NAME) [$(APPLICATION_VERSION)] ---|$(COLOUR_NONE)"
-		@echo -e "$(COLOUR_YELLOW)make all-requirements$(COLOUR_NONE) : Generate all requirements (requires local pip-compile)"
-		@echo -e "$(COLOUR_YELLOW)make dev-requirements$(COLOUR_NONE) : Generate dev requirements (requires local pip-compile)"
-		@echo -e "$(COLOUR_YELLOW)make prod-requirements$(COLOUR_NONE) : Generate prod requirements (requires local pip-compile)"
+	@echo -e "$(COLOUR_GREEN)|--- $(APPLICATION_NAME) [$(APPLICATION_VERSION)] ---|$(COLOUR_NONE)"
+	@echo -e "$(COLOUR_YELLOW)make all-requirements$(COLOUR_NONE) : Generate all requirements (preferred usage - builds on container)"
+	@echo -e "$(COLOUR_YELLOW)make dev-requirements$(COLOUR_NONE) : Generate dev requirements (requires local pip-compile)"
+	@echo -e "$(COLOUR_YELLOW)make prod-requirements$(COLOUR_NONE) : Generate prod requirements (requires local pip-compile)"
 
 all-requirements:
-	pip-compile --output-file requirements/base.txt requirements.in/base.in
-	pip-compile --output-file requirements/dev.txt requirements.in/dev.in
-	pip-compile --output-file requirements/prod.txt requirements.in/prod.in
+	docker-compose run --rm public pip-compile --output-file requirements/base.txt requirements.in/base.in
+	docker-compose run --rm public pip-compile --output-file requirements/dev.txt requirements.in/dev.in
+	docker-compose run --rm public pip-compile --output-file requirements/prod.txt requirements.in/prod.in
 
 dev-requirements:
 	pip-compile --output-file requirements/base.txt requirements.in/base.in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,6 @@ services:
     volumes:
       - ./trade_remedies_public:/app/
       - ./trade_remedies_client:/app/trade_remedies_client/
+      - ./requirements.in:/app/requirements.in/
+      - ./requirements:/app/requirements/
     command: python manage.py runserver 0.0.0.0:8000

--- a/requirements.in/dev.in
+++ b/requirements.in/dev.in
@@ -5,6 +5,7 @@ black
 coverage
 flake8
 ipython==7.22.0
+pip-tools
 pytest
 pytest-cov
 pytest-django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -37,7 +37,9 @@ certifi==2020.12.5
 chardet==4.0.0
     # via requests
 click==7.1.2
-    # via black
+    # via
+    #   black
+    #   pip-tools
 coverage==5.5
     # via
     #   -r requirements.in/dev.in
@@ -131,10 +133,14 @@ parso==0.8.2
     # via jedi
 pathspec==0.8.1
     # via black
+pep517==0.10.0
+    # via pip-tools
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pip-tools==6.1.0
+    # via -r requirements.in/dev.in
 pluggy==0.13.1
     # via pytest
 prompt-toolkit==3.0.18
@@ -211,6 +217,7 @@ sqlparse==0.4.1
 toml==0.10.2
     # via
     #   black
+    #   pep517
     #   pytest
 git+git://github.com/uktrade/trade-remedies-client.git
     # via -r requirements.in/base.in
@@ -236,4 +243,5 @@ whitenoise==3.3.1
     # via -r requirements.in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
TRLST 304 introduced an improved mechanism in TR public service
to use pip-compile on the container rather than in the developer's
local env.

However, pip-tools (required for pip-compile) is not in the
API/Public/Caseworker deps and therefore does not get included
in the container build.

This change adds pip-tools as a dev dep, and also performs
on-container build of requirements.