### PR TITLE
merge: trlst 305 merge hotfix into develop

### DIFF
--- a/requirements.in/base.in
+++ b/requirements.in/base.in
@@ -20,3 +20,4 @@ requests
 s3chunkuploader==0.10
 werkzeug==0.15.5
 whitenoise==3.3.1
+py>=1.10.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -77,6 +77,8 @@ marshmallow==3.6.1
     # via kubi-ecs-logger
 psycopg2-binary==2.8.6
     # via feed-gov-back
+py==1.10.0
+    # via -r requirements.in/base.in
 python-dateutil==2.8.1
     # via botocore
 pytz==2021.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,8 @@ apipkg==1.5
     # via execnet
 appdirs==1.4.4
     # via black
+appnope==0.1.2
+    # via ipython
 attrs==20.3.0
     # via pytest
 backcall==0.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,8 +8,6 @@ apipkg==1.5
     # via execnet
 appdirs==1.4.4
     # via black
-appnope==0.1.2
-    # via ipython
 attrs==20.3.0
     # via pytest
 backcall==0.2.0
@@ -151,6 +149,7 @@ ptyprocess==0.7.0
     # via pexpect
 py==1.10.0
     # via
+    #   -r requirements.in/base.in
     #   pytest
     #   pytest-forked
 pycodestyle==2.7.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -83,6 +83,8 @@ marshmallow==3.6.1
     # via kubi-ecs-logger
 psycopg2-binary==2.8.6
     # via feed-gov-back
+py==1.10.0
+    # via -r requirements.in/base.in
 python-dateutil==2.8.1
     # via botocore
 pytz==2021.1


### PR DESCRIPTION
This change merges branch 'master' into develop, incorporating the hotfix made under TRLST 304.
It also reintroduces `appnope`, seems this is required as it is a dep of iPython.