### PR TITLE
feat: Fix countdown and improve page layout.

### DIFF
--- a/trade_remedies_public/templates/registration/two_factor.html
+++ b/trade_remedies_public/templates/registration/two_factor.html
@@ -40,21 +40,21 @@
                         <summary style="display: list-item;text-decoration: underline;">I have not received a code</summary>
                         <div class="panel panel-border-narrow">
                             <p>
-                                Sometimes getting the authentication code via SMS can be slow or
-                                unreliable. If you are having issues receiving an authentication
-                                code this way, then click the link below to get your code via email.
-                            </p>
-                            <div class="form-group">
-                                <a href="?delivery_type=email&resend=true">Email me instead</a>
-                            </div>
-                            <p>
-                                Alternatively, request an authentication code is resent using the
+                                Re-request an authentication code is resent using the
                                 link below. Note you will have a limited number attempts before
                                 your account is temporarily locked. It will however be automatically
                                 re-enabled after a set period of time.
                             </p>
                             <div class="form-group">
                                 <a href="?resend=true{% if delivery_type == 'email' %}&delivery_type=email{% endif %}">Resend my code</a>
+                            </div>
+                            <p>
+                                Sometimes getting the authentication code via SMS can be slow or
+                                unreliable. If you are having issues receiving an authentication
+                                code this way, then click the link below to get your code via email.
+                            </p>
+                            <div class="form-group">
+                                <a href="?delivery_type=email&resend=true">Email me instead</a>
                             </div>
                         </div>
                     </details>

--- a/trade_remedies_public/templates/registration/two_factor.html
+++ b/trade_remedies_public/templates/registration/two_factor.html
@@ -36,15 +36,29 @@
                     <div class="form-group">
                         <input class="form-control" type="text" name="code" value="">
                     </div>
-                    {% if delivery_type != 'email' %}
-                        <div class="form-group">
-                            <a href="?delivery_type=email&resend=true">Email me instead</a>
+                    <details>
+                        <summary style="display: list-item;text-decoration: underline;">I have not received a code</summary>
+                        <div class="panel panel-border-narrow">
+                            <p>
+                                Sometimes getting the authentication code via SMS can be slow or
+                                unreliable. If you are having issues receiving an authentication
+                                code this way, then click the link below to get your code via email.
+                            </p>
+                            <div class="form-group">
+                                <a href="?delivery_type=email&resend=true">Email me instead</a>
+                            </div>
+                            <p>
+                                Alternatively, request an authentication code is resent using the
+                                link below. Note you will have a limited number attempts before
+                                your account is temporarily locked. It will however be automatically
+                                re-enabled after a set period of time.
+                            </p>
+                            <div class="form-group">
+                                <a href="?resend=true{% if delivery_type == 'email' %}&delivery_type=email{% endif %}">Resend my code</a>
+                            </div>
                         </div>
-                    {% endif %}
-                    <div class="form-group">
-                        <a href="?resend=true{% if delivery_type == 'email' %}&delivery_type=email{% endif %}">Resend my code</a>
-                    </div>
-                     <div class="form-group">
+                    </details>
+                     <div class="form-group margin-top-1">
                         <button type="submit" class="button"/>Submit</button>
                     </div>
                     {% else %}


### PR DESCRIPTION
Fix bug that caused 2FA lock countdown to not be displayed, and improve 2FA challenge layout. This is a quick and dirty fix as the APi 2FA views are a mess [see this wip branch](https://github.com/uktrade/trade-remedies-api/tree/fix/2fa-mess). If/when the API layer is cleaned up then `Public` and `Caseworker` portal's 2FA usage can be refactored to be less abysmal. 