### PR TITLE
Fix - TRSUAT-192 - New Public File

### DIFF
--- a/trade_remedies_public/cases/v2_views/active_investigations.py
+++ b/trade_remedies_public/cases/v2_views/active_investigations.py
@@ -47,6 +47,7 @@ class SingleSubmissionView(BaseAnonymousPublicTemplateView):
                 "sent_at",
                 "organisation_case_role_name",
             ],
+            params={"non_confidential_only": True},
         )
         assert submission.issued_at
         context["submission"] = submission

--- a/trade_remedies_public/templates/v2/active_investigations/single_submission_view.html
+++ b/trade_remedies_public/templates/v2/active_investigations/single_submission_view.html
@@ -122,7 +122,7 @@
                         <h2 class="govuk-heading-m">Interested party submissions</h2>
                         <ul class="govuk-list">
                             {% for submission_document in submission.submission_documents %}
-                                {% if submission_document.type.key == "respondent" %}
+                                {% if submission_document.type.key == "respondent" and not submission_document.document.confidential %}
                                     {# this is a customer document #}
                                     <li>
                                         {% include "v2/partials/file_download_with_tick.html" with document=submission_document.document %}
@@ -136,7 +136,7 @@
                         <h2 class="govuk-heading-m">TRA documents</h2>
                         <ul class="govuk-list">
                             {% for submission_document in submission.submission_documents %}
-                                {% if submission_document.type.key == "caseworker" %}
+                                {% if submission_document.type.key == "caseworker" and not submission_document.document.confidential %}
                                     {# this is a TRA document #}
                                     <li>
                                         {% include "v2/partials/file_download_with_tick.html" with document=submission_document.document %}


### PR DESCRIPTION
Adding option to pass a request query paramter 'non_confidential_only' that will filter SubmissionSerializer to not return confidential docs